### PR TITLE
Make CRUD controllers through resource option

### DIFF
--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/AlternativesController.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/AlternativesController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class AlternativesController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/ElectionsController.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/ElectionsController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class ElectionsController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/ProvincesController.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/ProvincesController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class ProvincesController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/VotesController.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/VotesController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class VotesController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}


### PR DESCRIPTION
# PR#3: Creating Controllers

## Description
In this PR, I've created a set of controllers that will be used to manage the core entities of the application. These controllers were generated using the --resource option, which provides a complete set of CRUD operations for each entity. The controllers created are as follows:

- `ElectionsController`
- `ProvincesController`
- `AlternativesController`
- `VotesController`

These controllers will serve as the backend logic for the application, handling the creation, retrieval, updating, and deletion of election-related data.

## Changes Made
- [x] Created a new branch named `feature/makeControllers`.
- [x] Generated four controllers using the `--resource` option:
  - `php artisan make:controller ElectionsController --resource`
  - `php artisan make:controller ProvincesController --resource`
  - `php artisan make:controller AlternativesController --resource`
  - `php artisan make:controller VotesController --resource`

## Usage
These controllers provide RESTful endpoints for interacting with the respective entities in the application.

## Next Steps (To-Do)
- [x] Define routes for CRUD operations in `web.php`. Use the `Route::resource` method for a cleaner route definition.
- [x] Create views for the CRUD operations and organize them within folders according to the application's logic.
- [x] Implement a base template layout (e.g., Bootstrap) to provide a consistent look and feel.
- [x] Extend the layout in the views.
- [x] Organize CRUD views within a `crud` folder.