### PR TITLE
Feature/elections crud

### DIFF
--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/ElectionsController.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/ElectionsController.php
@@ -13,9 +13,18 @@ class ElectionsController extends Controller
      * Display a listing of the resource.
      */
     public function index()
-    {
-        return view('entities.elections.index');
+{
+    $elections = Election::all();
+    $years = [];
+
+    foreach ($elections as $election) {
+        $year = strtotime($election->date);
+        $years[] = date("Y", $year);
     }
+
+    return view('entities.elections.index', compact('elections', 'years'));
+}
+
 
     /**
      * Show the form for creating a new resource.

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/ElectionsController.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/ElectionsController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
+use App\Models\Election;
 use Illuminate\Http\Request;
+
 
 class ElectionsController extends Controller
 {
@@ -42,9 +44,10 @@ class ElectionsController extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit(string $id)
+    public function edit(string $year)
     {
-        //
+        $election = Election::whereYear('date',$year)->first();
+        return view('entities.elections.edit')->with(['election' => $election, 'year' => $year]);
     }
 
     /**

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/ElectionsController.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/ElectionsController.php
@@ -13,19 +13,20 @@ class ElectionsController extends Controller
      * Display a listing of the resource.
      */
     public function index()
-{
-    $elections = Election::all();
-    $years = [];
+    {
+        $elections = Election::all();
+        $years = [];
 
-    foreach ($elections as $election) {
-        $year = strtotime($election->date);
-        $years[] = date("Y", $year);
+        foreach ($elections as $election) {
+            $year = strtotime($election->date);
+            $years[] = date("Y", $year);
+        }
+
+        return view('entities.elections.index')->with([
+            'elections' => $elections,
+            'years' => $years,
+        ]);
     }
-
-    return view('entities.elections.index', compact('elections', 'years'));
-}
-
-
     /**
      * Show the form for creating a new resource.
      */
@@ -33,45 +34,51 @@ class ElectionsController extends Controller
     {
         return view('entities.elections.create');
     }
-
     /**
      * Store a newly created resource in storage.
      */
     public function store(Request $request)
     {
-        //
-    }
+        $election = new Election();
+        $election->date = $request->get('date');
 
+        $election->save();
+
+        return redirect('/elections');
+    }
     /**
      * Display the specified resource.
      */
-    public function show(string $id)
+    public function show(string $year)
     {
-        //
+        $election = Election::whereYear('date', $year)->first();
+        return view('entities.elections.show')->with(['election' => $election, 'year' => $year]);
     }
-
     /**
      * Show the form for editing the specified resource.
      */
     public function edit(string $year)
     {
-        $election = Election::whereYear('date',$year)->first();
+        $election = Election::whereYear('date', $year)->first();
         return view('entities.elections.edit')->with(['election' => $election, 'year' => $year]);
     }
-
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id)
+    public function update(Request $request, string $year)
     {
-        //
+        $election = Election::whereYear('date', $year)->first();
+        $election->date = $request->get('date');
+        $election->save();
+        return redirect('/elections');
     }
-
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(string $id)
+    public function destroy(string $year)
     {
-        //
+        $election = Election::whereYear('date', $year)->first();
+        $election->delete();
+        return redirect('/elections');
     }
 }

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Models/Election.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Models/Election.php
@@ -9,17 +9,19 @@ class Election extends Model
 {
     use HasFactory;
     /**
-     * Define a one-to-many relationship with the Population model.
+     * Define the relationship between Election and Alternative through votes.
      */
-    public function populations()
+    public function elections_votes_alternatives()
     {
-        return $this->hasMany(Population::class);
+        return $this->belongsToMany(Alternative::class, 'votes')
+            ->withPivot('quantity'); // To get votes quantity in the relation
     }
     /**
-     * Define a one-to-many relationship with the Vote model.
+     * Define the relationship between Election and Province through votes.
      */
-    public function votes()
+    public function elections_votes_provinces()
     {
-        return $this->hasMany(Vote::class);
+        return $this->belongsToMany(Province::class, 'votes')
+            ->withPivot('quantity'); // To get votes quantity in the relation
     }
 }

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/database/seeders/ElectionsTableSeeder.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/database/seeders/ElectionsTableSeeder.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Election;
+
+class ElectionsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $electionsData = [
+            ['date' => '1983-10-30'],
+            ['date' => '1989-05-14'],
+            ['date' => '1995-05-14'],
+            ['date' => '1999-10-24'],
+            ['date' => '2002-04-27'],
+            ['date' => '2003-04-27'],
+            ['date' => '2007-10-28'],
+            ['date' => '2011-10-23'],
+            ['date' => '2015-11-22'],
+            ['date' => '2019-10-27'],
+        ];
+
+        foreach ($electionsData as $electionData) {
+            Election::create($electionData);
+        }
+    }
+}

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/elections/create.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/elections/create.blade.php
@@ -2,9 +2,8 @@
 
 @section('content')
     <h2 class="text-2xl font-semibold text-center mt-10">Add an Alternative</h2>
-    <form action="/elections/store" method="POST" class="mt-auto mx-auto max-w-md space-y-4">
+    <form action="/elections" method="POST" class="mt-auto mx-auto max-w-md space-y-4">
         @csrf
-
         <div>
             <label for="date" class="block text-gray-700">Date of election</label>
             <input id="date" name="date" type="date"

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/elections/create.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/elections/create.blade.php
@@ -1,1 +1,26 @@
-<h1>Create election</h1>
+@extends('layouts.main-layout')
+
+@section('content')
+    <h2 class="text-2xl font-semibold text-center mt-10">Add an Alternative</h2>
+    <form action="/elections/store" method="POST" class="mt-auto mx-auto max-w-md space-y-4">
+        @csrf
+
+        <div>
+            <label for="date" class="block text-gray-700">Date of election</label>
+            <input id="date" name="date" type="date"
+                class="border rounded px-3 py-2 w-full
+                @error('date') border-red-500 @enderror"
+                value="{{ old('date') }}" tabindex="1">
+            @error('name')
+                <small class="text-red-500">{{ $message }}</small>
+            @enderror
+        </div>
+        <div class="flex justify-between">
+            <a href="/" class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block"
+                tabindex="2">Cancel</a>
+            <button type="submit"
+                class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block"
+                tabindex="3">Submit</button>
+        </div>
+    </form>
+@endsection

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/elections/edit.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/elections/edit.blade.php
@@ -1,1 +1,27 @@
-<h1>Edit election</h1>
+@extends('layouts.main-layout')
+
+@section('content')
+    <h2 class="text-2xl font-semibold text-center mt-10">Edit an Election</h2>
+    <form action="/elections/{{ $year }}" method="POST" class="mt-auto mx-auto max-w-md space-y-4">
+        @csrf
+        @method('PUT')
+
+        <div>
+            <label for="date" class="block text-gray-700">Date of election</label>
+            <input id="date" name="date" type="date"
+                class="border rounded px-3 py-2 w-full
+                @error('date') border-red-500 @enderror"
+                value="{{ old('date', $election->date) }}" tabindex="1">
+            @error('date')
+                <small class="text-red-500">{{ $message }}</small>
+            @enderror
+        </div>
+        <div class="flex justify-between">
+            <a href="/" class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block"
+                tabindex="5">Cancel</a>
+            <button type="submit"
+                class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block"
+                tabindex="6">Submit</button>
+        </div>
+    </form>
+@endsection

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/elections/index.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/elections/index.blade.php
@@ -1,9 +1,9 @@
 @extends('layouts.main-layout')
 
 @section('content')
-    <h2 class="text-2xl font-semibold text-center mt-10">Elections</h2>
-    <div class="mt-4 mx-auto p-20">
-        <table class="min-w-full border-collapse border">
+    <h2 class="text-2xl font-semibold text-center mt-6">Elections</h2>
+    <div class="mx-auto px-20 py-5">
+        <table class="min-w-full border-collapse border mt-4">
             <thead>
                 <tr>
                     <th
@@ -33,7 +33,7 @@
         </table>
     </div>
 
-    <div class="text-center mt-4">
-        <a href="/" class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block">Back</a>
+    <div class="text-center">
+        <a href="/" class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 mb-4 rounded inline-block">Back</a>
     </div>
 @endsection

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/elections/index.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/elections/index.blade.php
@@ -1,1 +1,39 @@
-<h1>Elections Index View</h1>
+@extends('layouts.main-layout')
+
+@section('content')
+    <h2 class="text-2xl font-semibold text-center mt-10">Elections</h2>
+    <div class="mt-4 mx-auto p-20">
+        <table class="min-w-full border-collapse border">
+            <thead>
+                <tr>
+                    <th
+                        class="px-6 py-3 bg-gray-200 text-left text-xs leading-4 font-big text-gray-600 uppercase tracking-wider">
+                        Election date</th>
+                    <th class="px-6 py-3 bg-gray-200"></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach ($elections as $election)
+                    <tr>
+                        <td class="border px-6 py-4">{{ $election->date }}</td>
+                        <td class="border px-6 py-4 text-right">
+                            <a href="{{ route('elections.edit', $years[$loop->index]) }}"
+                                class="text-white bg-blue-400 hover:bg-blue-700 font-bold py-2 px-4 m-4 rounded mr-3">Edit</a>
+                            <form action="{{ route('elections.destroy', $years[$loop->index]) }}" method="POST"
+                                class="inline">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit"
+                                    class="text-white bg-red-600 hover:bg-red-900 font-bold py-2 px-4 m-4 rounded mr-3">Delete</button>
+                            </form>
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+
+    <div class="text-center mt-4">
+        <a href="/" class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block">Back</a>
+    </div>
+@endsection

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/elections/show.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/elections/show.blade.php
@@ -1,0 +1,18 @@
+@extends('layouts.main-layout')
+
+@section('content')
+    <h2 class="text-2xl font-semibold text-center mt-10">{{ $year }}'s election date</h2>
+    <div class="mt-auto mx-auto max-w-md space-y-4">
+        <table>
+            <div>
+                <label for="date" class="block text-gray-700 py-3">Election's date</label>
+                <div id="date" date="date" type="text" class="border rounded px-3 py-2 w-full text-center">
+                    {{ $election->date }}
+                </div>
+            </div>
+        </table>
+        <div class="text-center mt-4">
+            <a href="/elections"
+                class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block">Back</a>
+        </div>
+    @endsection


### PR DESCRIPTION
This pull request enhances the management of elections, allowing them to be accessed by year. 
## Key changes
- improvements to the ElectionsController.
- Database seeding using ElectionsTableSeeder.
- Adjustments to the Election model.
- Introduction of new views for editing and displaying elections.
## Details
### `ElectionsController.php`
- `edit()`: Edited to access the election through its year in the URL instead of its id.
- `index()`: Set to display all elections and added a function to access the year in the "edit" and "delete" links of the buttons.
- `store()`: Set to save a new election.
- `show()`, `update()`, and `destroy()`: Set to view, change, and delete a particular election through its year instead of its id.
### `ElectionsTableSeeder.php`
- Created a seeder using `php artisan make:seeder ElectionsTableSeeder` and populated it with the last 10 election dates to add them to the database.
 - Executed the seeder with `php artisan db:seed --class=ElectionsTableSeeder`.
### `Election.php`
- Added two `belongsToMany` relationships to relate elections with provinces and alternatives, respectively.
### `views.entities.elections.edit`
- Implemented a simple form for editing the date of an election.
### `views.entities.elections.index`
- Created a basic table to display all elections, utilizing `$loop` to access the current loop of the main iteration.
### `views.entities.elections.create`
- A simple form to create a new election.
- Use of post method.
- [x] Set `@error`.
- [x] Set the correct URL for "cancel".
### `views.entities.elections.show`
- A simple container to show an election.
- [x] Add a "delete" button.
### Next Steps (To-Do):
- [x] Correct the tabindex in the forms.
- [x] Add a delete button in the show view and view in index (that goes to show).