### PR TITLE
Feature/votes crud

### DIFF
--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/VotesController.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/VotesController.php
@@ -71,7 +71,7 @@ class VotesController extends Controller
         $year = date('Y', strtotime($date));
 
         // Correct way to use routes:
-        return redirect(route('votes.findVotes', [$year, $vote->province_id, $vote->alternative_id]));
+        return redirect(route('votes.showVote', [$year, $vote->province_id, $vote->alternative_id]));
         //Old: return redirect('votes/{year}/{province_id}/{alternative_id}');
     }
 

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/VotesController.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Http/Controllers/VotesController.php
@@ -4,62 +4,215 @@ namespace App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use App\Models\Election;
+use App\Models\Province;
+use App\Models\Alternative;
+use App\Models\Vote;
 
 class VotesController extends Controller
 {
     /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        return view('entities.votes.index');
-    }
-
-    /**
      * Show the form for creating a new resource.
      */
+
     public function create()
     {
-        return view('entities.votes.create');
+        $elections = Election::orderby('date', 'desc')->get();
+        $provinces = Province::orderby('id')->get();
+        $alternatives = Alternative::orderby('id')->get();
+
+        return view('entities.votes.create', compact('elections', 'provinces', 'alternatives'));
     }
 
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+
+    public function store(Request $request,)
     {
-        //
+        $this->validate($request, [
+            'election' => 'required|numeric',
+            'province' => 'required|numeric',
+            'alternative' => 'required|numeric',
+            'quantity' => 'required|numeric|min:0',
+        ]);
+
+        // Check if there is a vote with those PK
+        $existingVote = Vote::where([
+            'election_id' => $request->input('election'),
+            'province_id' => $request->input('province'),
+            'alternative_id' => $request->input('alternative'),
+        ])->first();
+
+        if ($existingVote) {
+            // Making the url to go to the specific year by the election_id
+            // TODO: This is a too much complicated logic only to want use the year in the URL instead of election id.
+            $selectedElection = Election::find($request->input('election'));
+            $selectedYear = $selectedElection ? date('Y', strtotime($selectedElection->date)) : '';
+            $editLink = route('votes.edit', [$selectedYear, $request->input('province'), $request->input('alternative')]);
+
+            // Show error message
+            return redirect()->back()->withInput()
+                ->with('error', 'These votes are already have this value, change them in EDIT')
+                ->with('editLink', $editLink)
+                ->with('existingVotes', $existingVote->quantity);
+        }
+        // Vote::create($request->all()); TODO Is this the correct way to create a new Vote?
+        // Old or different method to create a new register
+        $vote = new Vote();
+        $vote->election_id = $request->get('election');
+        $vote->province_id = $request->get('province');
+        $vote->alternative_id = $request->get('alternative');
+        $vote->quantity = $request->get('quantity');
+
+        $vote->save();
+        // Send the $year value to the view from the election date
+        $date = $vote->election->date;
+        $year = date('Y', strtotime($date));
+
+        // Correct way to use routes:
+        return redirect(route('votes.findVotes', [$year, $vote->province_id, $vote->alternative_id]));
+        //Old: return redirect('votes/{year}/{province_id}/{alternative_id}');
     }
 
     /**
-     * Display the specified resource.
+     * Display votes for one alternative in one province in one election.
      */
-    public function show(string $id)
+
+    public function showVote($year, $province_id, $alternative_id)
     {
-        //
+        // Find the election based on the provided year
+        $election = Election::whereYear('date', $year)->first();
+        // Check if the election was found
+        if (!$election) {
+            return abort(404); // TODO: Handle the case where the election is not found
+        }
+        // Find the vote based on the election_id, province_id, and alternative_id using eloquent
+        $vote = Vote::where([
+            'election_id' => $election->id,
+            'province_id' => $province_id,
+            'alternative_id' => $alternative_id,
+        ])->first();
+
+        // Check if the vote was found
+        if (!$vote) {
+            // Show error message
+            return redirect('/votes/create')->withInput()
+                ->with('error', 'These votes are not charged, please do it!');
+        }
+        return view('entities.votes.show-vote', compact(['vote', 'year']));
     }
 
     /**
-     * Show the form for editing the specified resource.
+     * Show the form to edit the specified resource.
      */
-    public function edit(string $id)
+
+    public function edit(Request $request, $year, $province_id, $alternative_id)
     {
-        //
+        $elections = Election::orderby('date', 'desc')->get();
+        $provinces = Province::orderby('id')->get();
+        $alternatives = Alternative::orderby('id')->get();
+
+        // Find the election based on the provided year
+        $election = Election::whereYear('date', $year)->first();
+        // Check if the election was found
+        if (!$election) {
+            return abort(404); // TODO: Handle the case where the election is not found
+        }
+        $vote = Vote::where([
+            'election_id' => $election->id,
+            'province_id' => $province_id,
+            'alternative_id' => $alternative_id,
+        ])->first(); //TODO set the exception in app\Exceptions\Handler.php
+        if (!$vote) {
+            // Show error message
+            return redirect('/votes/create')->withInput()
+                ->with('error', 'These votes are not charged, please do it!');
+        }
+        return view('entities.votes.edit', compact('elections', 'provinces', 'alternatives', 'vote', 'year'));
     }
 
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id)
+
+    public function update(Request $request)
     {
-        //
+        // Validates inputs
+        $this->validate($request, [
+            'election' => 'required|numeric',
+            'province' => 'required|numeric',
+            'alternative' => 'required|numeric',
+            'quantity' => 'required|numeric|min:0',
+        ]);
+        $existingVote = Vote::where([
+            'election_id' => $request->input('election'),
+            'province_id' => $request->input('province'),
+            'alternative_id' => $request->input('alternative'),
+        ])->first();
+        if ($existingVote) {
+            Vote::where([
+                'election_id' => $request->election,
+                'province_id' => $request->province,
+                'alternative_id' => $request->alternative,
+            ])->update([
+                'election_id' => $request->election,
+                'province_id' => $request->province,
+                'alternative_id' => $request->alternative,
+                'quantity' => $request->quantity ? $request->quantity : 0,
+            ]);
+        } else {
+            Vote::create([
+                'election_id' => $request->election,
+                'province_id' => $request->province,
+                'alternative_id' => $request->alternative,
+                'quantity' => $request->quantity
+            ]);
+        }
+        // Get the new vote's year to send to the url
+        $electionDate = Election::where([
+            'id' => $request->election
+        ])->first()->date;
+        if (!$electionDate) {
+            return abort(404); // TODO: Handle the case where the election is not found
+        }
+        $year = date('Y', strtotime($electionDate));
+        return redirect(route('results.showByYear', $year));
     }
 
     /**
-     * Remove the specified resource from storage.
+     * Remove the specified vote from that year(id), that province, that alternative.
      */
-    public function destroy(string $id)
+
+    public function destroy(Request $request, $election_id, $province_id, $alternative_id)
     {
-        //
+        //Checks if is coming from edit or whow view
+        if ($request->election) {
+            // Deletes if comes from edit vote view
+            Vote::where([
+                'election_id' => $request->election,
+                'province_id' => $request->province,
+                'alternative_id' => $request->alternative,
+            ])->delete();
+        } else {
+            // Deletes if comes from show vote view
+            Vote::where([
+                'election_id' => $election_id,
+                'province_id' => $province_id,
+                'alternative_id' => $alternative_id,
+            ])->delete();
+        }
+
+        // Get the new vote's year to send to the url
+        $election = Election::where([
+            'id' => $election_id
+        ])->first();
+        if (!$election) {
+            return abort(404); // TODO: Handle the case where the election is not found
+        }
+        $electionDate = $election->date;
+        $year = date('Y', strtotime($electionDate));
+
+        return redirect(route('results.showByYear', $year));
     }
 }

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Models/Vote.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/app/Models/Vote.php
@@ -8,20 +8,30 @@ use Illuminate\Database\Eloquent\Model;
 
 class Vote extends Model
 {
+    // Set the colums that form the primary key
+    protected $primaryKey = ['election_id', 'province_id', 'alternative_id'];
+    public $incrementing = false;
+
     use HasFactory;
 
     public function election()
     {
-        return $this->belongsTo(Election::class, 'election_id', 'id');
+        return $this->belongsTo(Election::class);
     }
 
     public function alternative()
     {
-        return $this->belongsTo(Alternative::class, 'alternative_id', 'id');
+        return $this->belongsTo(Alternative::class);
     }
 
     public function province()
     {
-        return $this->belongsTo(Province::class, 'province_id', 'id');
+        return $this->belongsTo(Province::class);
     }
+    protected $fillable = [
+        'election_id',
+        'province_id',
+        'alternative_id',
+        'quantity'
+    ];
 }

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/database/migrations/2023_09_10_205121_create_votes_table.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/database/migrations/2023_09_10_205121_create_votes_table.php
@@ -12,7 +12,6 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('votes', function (Blueprint $table) {
-            $table->id();
             $table->unsignedInteger('quantity');
             $table->unsignedBigInteger('alternative_id');
             $table->unsignedBigInteger('province_id');
@@ -20,9 +19,12 @@ return new class extends Migration
             $table->timestamps();
 
             // Define foreign key constraints
-            $table->foreign('election_id')->references('id')->on('elections')->onDelete('cascade');
-            $table->foreign('province_id')->references('id')->on('provinces')->onDelete('cascade');
-            $table->foreign('alternative_id')->references('id')->on('alternatives')->onDelete('cascade');
+            $table->primary(['election_id', 'province_id', 'alternative_id']);
+
+            // Define foreign key constraints
+            $table->foreign('election_id')->references('id')->on('elections');
+            $table->foreign('province_id')->references('id')->on('provinces');
+            $table->foreign('alternative_id')->references('id')->on('alternatives');
         });
     }
 

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/database/seeders/Votes2019Seeder.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/database/seeders/Votes2019Seeder.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Vote;
+
+class Votes2019Seeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $votesData = [
+            // CABA
+            ['election_id' => 10, 'province_id' => 1, 'alternative_id' => 1, 'quantity' => 719655],
+            ['election_id' => 10, 'province_id' => 1, 'alternative_id' => 2, 'quantity' => 1068134],
+            ['election_id' => 10, 'province_id' => 1, 'alternative_id' => 3, 'quantity' => 130475],
+            ['election_id' => 10, 'province_id' => 1, 'alternative_id' => 4, 'quantity' => 59066],
+            ['election_id' => 10, 'province_id' => 1, 'alternative_id' => 5, 'quantity' => 13863],
+            ['election_id' => 10, 'province_id' => 1, 'alternative_id' => 6, 'quantity' => 38013],
+            ['election_id' => 10, 'province_id' => 1, 'alternative_id' => 7, 'quantity' => 31085],
+            ['election_id' => 10, 'province_id' => 1, 'alternative_id' => 8, 'quantity' => 15143],
+            // Buenos Aires
+            ['election_id' => 10, 'province_id' => 2, 'alternative_id' => 1, 'quantity' => 5294879],
+            ['election_id' => 10, 'province_id' => 2, 'alternative_id' => 2, 'quantity' => 3640552],
+            ['election_id' => 10, 'province_id' => 2, 'alternative_id' => 3, 'quantity' => 638990],
+            ['election_id' => 10, 'province_id' => 2, 'alternative_id' => 4, 'quantity' => 273495],
+            ['election_id' => 10, 'province_id' => 2, 'alternative_id' => 5, 'quantity' => 150067],
+            ['election_id' => 10, 'province_id' => 2, 'alternative_id' => 6, 'quantity' => 145743],
+            ['election_id' => 10, 'province_id' => 2, 'alternative_id' => 7, 'quantity' => 155421],
+            ['election_id' => 10, 'province_id' => 2, 'alternative_id' => 8, 'quantity' => 75346],
+            // Catamarca
+            ['election_id' => 10, 'province_id' => 3, 'alternative_id' => 1, 'quantity' => 132590],
+            ['election_id' => 10, 'province_id' => 3, 'alternative_id' => 2, 'quantity' => 79568],
+            ['election_id' => 10, 'province_id' => 3, 'alternative_id' => 3, 'quantity' => 13197],
+            ['election_id' => 10, 'province_id' => 3, 'alternative_id' => 4, 'quantity' => 3508],
+            ['election_id' => 10, 'province_id' => 3, 'alternative_id' => 5, 'quantity' => 2136],
+            ['election_id' => 10, 'province_id' => 3, 'alternative_id' => 6, 'quantity' => 3011],
+            ['election_id' => 10, 'province_id' => 3, 'alternative_id' => 7, 'quantity' => 23100],
+            ['election_id' => 10, 'province_id' => 3, 'alternative_id' => 8, 'quantity' => 1841],
+            // Córdoba
+            ['election_id' => 10, 'province_id' => 4, 'alternative_id' => 1, 'quantity' => 666445],
+            ['election_id' => 10, 'province_id' => 4, 'alternative_id' => 2, 'quantity' => 1394104],
+            ['election_id' => 10, 'province_id' => 4, 'alternative_id' => 3, 'quantity' => 113734],
+            ['election_id' => 10, 'province_id' => 4, 'alternative_id' => 4, 'quantity' => 37612],
+            ['election_id' => 10, 'province_id' => 4, 'alternative_id' => 5, 'quantity' => 31869],
+            ['election_id' => 10, 'province_id' => 4, 'alternative_id' => 6, 'quantity' => 30213],
+            ['election_id' => 10, 'province_id' => 4, 'alternative_id' => 7, 'quantity' => 42753],
+            ['election_id' => 10, 'province_id' => 4, 'alternative_id' => 8, 'quantity' => 25736],
+            // Corrientes
+            ['election_id' => 10, 'province_id' => 5, 'alternative_id' => 1, 'quantity' => 354968],
+            ['election_id' => 10, 'province_id' => 5, 'alternative_id' => 2, 'quantity' => 290690],
+            ['election_id' => 10, 'province_id' => 5, 'alternative_id' => 3, 'quantity' => 21658],
+            ['election_id' => 10, 'province_id' => 5, 'alternative_id' => 4, 'quantity' => 6522],
+            ['election_id' => 10, 'province_id' => 5, 'alternative_id' => 5, 'quantity' => 12515],
+            ['election_id' => 10, 'province_id' => 5, 'alternative_id' => 6, 'quantity' => 7044],
+            ['election_id' => 10, 'province_id' => 5, 'alternative_id' => 7, 'quantity' => 7062],
+            ['election_id' => 10, 'province_id' => 5, 'alternative_id' => 8, 'quantity' => 6009],
+            // Chaco
+            ['election_id' => 10, 'province_id' => 6, 'alternative_id' => 1, 'quantity' => 404758],
+            ['election_id' => 10, 'province_id' => 6, 'alternative_id' => 2, 'quantity' => 258432],
+            ['election_id' => 10, 'province_id' => 6, 'alternative_id' => 3, 'quantity' => 27636],
+            ['election_id' => 10, 'province_id' => 6, 'alternative_id' => 4, 'quantity' => 6986],
+            ['election_id' => 10, 'province_id' => 6, 'alternative_id' => 5, 'quantity' => 19617],
+            ['election_id' => 10, 'province_id' => 6, 'alternative_id' => 6, 'quantity' => 7856],
+            ['election_id' => 10, 'province_id' => 6, 'alternative_id' => 7, 'quantity' => 6836],
+            ['election_id' => 10, 'province_id' => 6, 'alternative_id' => 8, 'quantity' => 4534],
+            // Chubut
+            ['election_id' => 10, 'province_id' => 7, 'alternative_id' => 1, 'quantity' => 174726],
+            ['election_id' => 10, 'province_id' => 7, 'alternative_id' => 2, 'quantity' => 97837],
+            ['election_id' => 10, 'province_id' => 7, 'alternative_id' => 3, 'quantity' => 25357],
+            ['election_id' => 10, 'province_id' => 7, 'alternative_id' => 4, 'quantity' => 13117],
+            ['election_id' => 10, 'province_id' => 7, 'alternative_id' => 5, 'quantity' => 14253],
+            ['election_id' => 10, 'province_id' => 7, 'alternative_id' => 6, 'quantity' => 8029],
+            ['election_id' => 10, 'province_id' => 7, 'alternative_id' => 7, 'quantity' => 8384],
+            ['election_id' => 10, 'province_id' => 7, 'alternative_id' => 8, 'quantity' => 5864],
+            // Entre Ríos
+            ['election_id' => 10, 'province_id' => 8, 'alternative_id' => 1, 'quantity' => 390587],
+            ['election_id' => 10, 'province_id' => 8, 'alternative_id' => 2, 'quantity' => 391495],
+            ['election_id' => 10, 'province_id' => 8, 'alternative_id' => 3, 'quantity' => 55030],
+            ['election_id' => 10, 'province_id' => 8, 'alternative_id' => 4, 'quantity' => 14504],
+            ['election_id' => 10, 'province_id' => 8, 'alternative_id' => 5, 'quantity' => 14647],
+            ['election_id' => 10, 'province_id' => 8, 'alternative_id' => 6, 'quantity' => 14111],
+            ['election_id' => 10, 'province_id' => 8, 'alternative_id' => 7, 'quantity' => 6640],
+            ['election_id' => 10, 'province_id' => 8, 'alternative_id' => 8, 'quantity' => 7945],
+            // Formosa
+            ['election_id' => 10, 'province_id' => 9, 'alternative_id' => 1, 'quantity' => 229774],
+            ['election_id' => 10, 'province_id' => 9, 'alternative_id' => 2, 'quantity' => 100280],
+            ['election_id' => 10, 'province_id' => 9, 'alternative_id' => 3, 'quantity' => 11057],
+            ['election_id' => 10, 'province_id' => 9, 'alternative_id' => 4, 'quantity' => 3112],
+            ['election_id' => 10, 'province_id' => 9, 'alternative_id' => 5, 'quantity' => 5334],
+            ['election_id' => 10, 'province_id' => 9, 'alternative_id' => 6, 'quantity' => 2797],
+            ['election_id' => 10, 'province_id' => 9, 'alternative_id' => 7, 'quantity' => 2749],
+            ['election_id' => 10, 'province_id' => 9, 'alternative_id' => 8, 'quantity' => 2388],
+            // Jujuy
+            ['election_id' => 10, 'province_id' => 10, 'alternative_id' => 1, 'quantity' => 197119],
+            ['election_id' => 10, 'province_id' => 10, 'alternative_id' => 2, 'quantity' => 186104],
+            ['election_id' => 10, 'province_id' => 10, 'alternative_id' => 3, 'quantity' => 26835],
+            ['election_id' => 10, 'province_id' => 10, 'alternative_id' => 4, 'quantity' => 9241],
+            ['election_id' => 10, 'province_id' => 10, 'alternative_id' => 5, 'quantity' => 10512],
+            ['election_id' => 10, 'province_id' => 10, 'alternative_id' => 6, 'quantity' => 8617],
+            ['election_id' => 10, 'province_id' => 10, 'alternative_id' => 7, 'quantity' => 3665],
+            ['election_id' => 10, 'province_id' => 10, 'alternative_id' => 8, 'quantity' => 4951],
+            // La Pampa
+            ['election_id' => 10, 'province_id' => 11, 'alternative_id' => 1, 'quantity' => 115095],
+            ['election_id' => 10, 'province_id' => 11, 'alternative_id' => 2, 'quantity' => 86744],
+            ['election_id' => 10, 'province_id' => 11, 'alternative_id' => 3, 'quantity' => 15137],
+            ['election_id' => 10, 'province_id' => 11, 'alternative_id' => 4, 'quantity' => 4727],
+            ['election_id' => 10, 'province_id' => 11, 'alternative_id' => 5, 'quantity' => 4676],
+            ['election_id' => 10, 'province_id' => 11, 'alternative_id' => 6, 'quantity' => 3471],
+            ['election_id' => 10, 'province_id' => 11, 'alternative_id' => 7, 'quantity' => 1479],
+            ['election_id' => 10, 'province_id' => 11, 'alternative_id' => 8, 'quantity' => 2186],
+            // La Rioja
+            ['election_id' => 10, 'province_id' => 12, 'alternative_id' => 1, 'quantity' => 85779],
+            ['election_id' => 10, 'province_id' => 12, 'alternative_id' => 2, 'quantity' => 80462],
+            ['election_id' => 10, 'province_id' => 12, 'alternative_id' => 3, 'quantity' => 7844],
+            ['election_id' => 10, 'province_id' => 12, 'alternative_id' => 4, 'quantity' => 2127],
+            ['election_id' => 10, 'province_id' => 12, 'alternative_id' => 5, 'quantity' => 1987],
+            ['election_id' => 10, 'province_id' => 12, 'alternative_id' => 6, 'quantity' => 2801],
+            ['election_id' => 10, 'province_id' => 12, 'alternative_id' => 7, 'quantity' => 50804],
+            ['election_id' => 10, 'province_id' => 12, 'alternative_id' => 8, 'quantity' => 2160],
+            // Mendoza
+            ['election_id' => 10, 'province_id' => 13, 'alternative_id' => 1, 'quantity' => 435313],
+            ['election_id' => 10, 'province_id' => 13, 'alternative_id' => 2, 'quantity' => 576493],
+            ['election_id' => 10, 'province_id' => 13, 'alternative_id' => 3, 'quantity' => 75448],
+            ['election_id' => 10, 'province_id' => 13, 'alternative_id' => 4, 'quantity' => 26315],
+            ['election_id' => 10, 'province_id' => 13, 'alternative_id' => 5, 'quantity' => 22715],
+            ['election_id' => 10, 'province_id' => 13, 'alternative_id' => 6, 'quantity' => 14370],
+            ['election_id' => 10, 'province_id' => 13, 'alternative_id' => 7, 'quantity' => 8494],
+            ['election_id' => 10, 'province_id' => 13, 'alternative_id' => 8, 'quantity' => 15408],
+            // Misiones
+            ['election_id' => 10, 'province_id' => 14, 'alternative_id' => 1, 'quantity' => 417752],
+            ['election_id' => 10, 'province_id' => 14, 'alternative_id' => 2, 'quantity' => 245254],
+            ['election_id' => 10, 'province_id' => 14, 'alternative_id' => 3, 'quantity' => 24451],
+            ['election_id' => 10, 'province_id' => 14, 'alternative_id' => 4, 'quantity' => 6704],
+            ['election_id' => 10, 'province_id' => 14, 'alternative_id' => 5, 'quantity' => 21239],
+            ['election_id' => 10, 'province_id' => 14, 'alternative_id' => 6, 'quantity' => 8537],
+            ['election_id' => 10, 'province_id' => 14, 'alternative_id' => 7, 'quantity' => 12194],
+            ['election_id' => 10, 'province_id' => 14, 'alternative_id' => 8, 'quantity' => 6357],
+            // Neuquén
+            ['election_id' => 10, 'province_id' => 15, 'alternative_id' => 1, 'quantity' => 194195],
+            ['election_id' => 10, 'province_id' => 15, 'alternative_id' => 2, 'quantity' => 151939],
+            ['election_id' => 10, 'province_id' => 15, 'alternative_id' => 3, 'quantity' => 25628],
+            ['election_id' => 10, 'province_id' => 15, 'alternative_id' => 4, 'quantity' => 15199],
+            ['election_id' => 10, 'province_id' => 15, 'alternative_id' => 5, 'quantity' => 11743],
+            ['election_id' => 10, 'province_id' => 15, 'alternative_id' => 6, 'quantity' => 8167],
+            ['election_id' => 10, 'province_id' => 15, 'alternative_id' => 7, 'quantity' => 13277],
+            ['election_id' => 10, 'province_id' => 15, 'alternative_id' => 8, 'quantity' => 6741],
+            // Río Negro
+            ['election_id' => 10, 'province_id' => 16, 'alternative_id' => 1, 'quantity' => 247664],
+            ['election_id' => 10, 'province_id' => 16, 'alternative_id' => 2, 'quantity' => 123674],
+            ['election_id' => 10, 'province_id' => 16, 'alternative_id' => 3, 'quantity' => 27483],
+            ['election_id' => 10, 'province_id' => 16, 'alternative_id' => 4, 'quantity' => 11252],
+            ['election_id' => 10, 'province_id' => 16, 'alternative_id' => 5, 'quantity' => 14173],
+            ['election_id' => 10, 'province_id' => 16, 'alternative_id' => 6, 'quantity' => 8482],
+            ['election_id' => 10, 'province_id' => 16, 'alternative_id' => 7, 'quantity' => 13158],
+            ['election_id' => 10, 'province_id' => 16, 'alternative_id' => 8, 'quantity' => 6262],
+            // Salta
+            ['election_id' => 10, 'province_id' => 17, 'alternative_id' => 1, 'quantity' => 374369],
+            ['election_id' => 10, 'province_id' => 17, 'alternative_id' => 2, 'quantity' => 266406],
+            ['election_id' => 10, 'province_id' => 17, 'alternative_id' => 3, 'quantity' => 82358],
+            ['election_id' => 10, 'province_id' => 17, 'alternative_id' => 4, 'quantity' => 13625],
+            ['election_id' => 10, 'province_id' => 17, 'alternative_id' => 5, 'quantity' => 16635],
+            ['election_id' => 10, 'province_id' => 17, 'alternative_id' => 6, 'quantity' => 13378],
+            ['election_id' => 10, 'province_id' => 17, 'alternative_id' => 7, 'quantity' => 8868],
+            ['election_id' => 10, 'province_id' => 17, 'alternative_id' => 8, 'quantity' => 8099],
+            // San Juan
+            ['election_id' => 10, 'province_id' => 18, 'alternative_id' => 1, 'quantity' => 241960],
+            ['election_id' => 10, 'province_id' => 18, 'alternative_id' => 2, 'quantity' => 160449],
+            ['election_id' => 10, 'province_id' => 18, 'alternative_id' => 3, 'quantity' => 33004],
+            ['election_id' => 10, 'province_id' => 18, 'alternative_id' => 4, 'quantity' => 6928],
+            ['election_id' => 10, 'province_id' => 18, 'alternative_id' => 5, 'quantity' => 8388],
+            ['election_id' => 10, 'province_id' => 18, 'alternative_id' => 6, 'quantity' => 5759],
+            ['election_id' => 10, 'province_id' => 18, 'alternative_id' => 7, 'quantity' => 4217],
+            ['election_id' => 10, 'province_id' => 18, 'alternative_id' => 8, 'quantity' => 4124],
+            // San Luis
+            ['election_id' => 10, 'province_id' => 19, 'alternative_id' => 1, 'quantity' => 129118],
+            ['election_id' => 10, 'province_id' => 19, 'alternative_id' => 2, 'quantity' => 139479],
+            ['election_id' => 10, 'province_id' => 19, 'alternative_id' => 3, 'quantity' => 19954],
+            ['election_id' => 10, 'province_id' => 19, 'alternative_id' => 4, 'quantity' => 7171],
+            ['election_id' => 10, 'province_id' => 19, 'alternative_id' => 5, 'quantity' => 7683],
+            ['election_id' => 10, 'province_id' => 19, 'alternative_id' => 6, 'quantity' => 5354],
+            ['election_id' => 10, 'province_id' => 19, 'alternative_id' => 7, 'quantity' => 3957],
+            ['election_id' => 10, 'province_id' => 19, 'alternative_id' => 8, 'quantity' => 4119],
+            // Santa Cruz
+            ['election_id' => 10, 'province_id' => 20, 'alternative_id' => 1, 'quantity' => 108323],
+            ['election_id' => 10, 'province_id' => 20, 'alternative_id' => 2, 'quantity' => 51183],
+            ['election_id' => 10, 'province_id' => 20, 'alternative_id' => 3, 'quantity' => 9123],
+            ['election_id' => 10, 'province_id' => 20, 'alternative_id' => 4, 'quantity' => 6032],
+            ['election_id' => 10, 'province_id' => 20, 'alternative_id' => 5, 'quantity' => 5171],
+            ['election_id' => 10, 'province_id' => 20, 'alternative_id' => 6, 'quantity' => 1402],
+            ['election_id' => 10, 'province_id' => 20, 'alternative_id' => 7, 'quantity' => 5181],
+            ['election_id' => 10, 'province_id' => 20, 'alternative_id' => 8, 'quantity' => 2468],
+            // Santa Fe
+            ['election_id' => 10, 'province_id' => 21, 'alternative_id' => 1, 'quantity' => 9192],
+            ['election_id' => 10, 'province_id' => 21, 'alternative_id' => 2, 'quantity' => 937611],
+            ['election_id' => 10, 'province_id' => 21, 'alternative_id' => 3, 'quantity' => 193603],
+            ['election_id' => 10, 'province_id' => 21, 'alternative_id' => 4, 'quantity' => 30862],
+            ['election_id' => 10, 'province_id' => 21, 'alternative_id' => 5, 'quantity' => 33247],
+            ['election_id' => 10, 'province_id' => 21, 'alternative_id' => 6, 'quantity' => 40353],
+            ['election_id' => 10, 'province_id' => 21, 'alternative_id' => 7, 'quantity' => 14121],
+            ['election_id' => 10, 'province_id' => 21, 'alternative_id' => 8, 'quantity' => 29501],
+            // Santiago del Estero
+            ['election_id' => 10, 'province_id' => 22, 'alternative_id' => 1, 'quantity' => 451082],
+            ['election_id' => 10, 'province_id' => 22, 'alternative_id' => 2, 'quantity' => 110525],
+            ['election_id' => 10, 'province_id' => 22, 'alternative_id' => 3, 'quantity' => 19103],
+            ['election_id' => 10, 'province_id' => 22, 'alternative_id' => 4, 'quantity' => 5755],
+            ['election_id' => 10, 'province_id' => 22, 'alternative_id' => 5, 'quantity' => 9219],
+            ['election_id' => 10, 'province_id' => 22, 'alternative_id' => 6, 'quantity' => 5123],
+            ['election_id' => 10, 'province_id' => 22, 'alternative_id' => 7, 'quantity' => 6652],
+            ['election_id' => 10, 'province_id' => 22, 'alternative_id' => 8, 'quantity' => 3272],
+            // Tierra del Fuego
+            ['election_id' => 10, 'province_id' => 23, 'alternative_id' => 1, 'quantity' => 57887],
+            ['election_id' => 10, 'province_id' => 23, 'alternative_id' => 2, 'quantity' => 26529],
+            ['election_id' => 10, 'province_id' => 23, 'alternative_id' => 3, 'quantity' => 7785],
+            ['election_id' => 10, 'province_id' => 23, 'alternative_id' => 4, 'quantity' => 2760],
+            ['election_id' => 10, 'province_id' => 23, 'alternative_id' => 5, 'quantity' => 3925],
+            ['election_id' => 10, 'province_id' => 23, 'alternative_id' => 6, 'quantity' => 2803],
+            ['election_id' => 10, 'province_id' => 23, 'alternative_id' => 7, 'quantity' => 1340],
+            ['election_id' => 10, 'province_id' => 23, 'alternative_id' => 8, 'quantity' => 1868],
+            // Tucumán
+            ['election_id' => 10, 'province_id' => 24, 'alternative_id' => 1, 'quantity' => 591686],
+            ['election_id' => 10, 'province_id' => 24, 'alternative_id' => 2, 'quantity' => 347642],
+            ['election_id' => 10, 'province_id' => 24, 'alternative_id' => 3, 'quantity' => 42432],
+            ['election_id' => 10, 'province_id' => 24, 'alternative_id' => 4, 'quantity' => 12598],
+            ['election_id' => 10, 'province_id' => 24, 'alternative_id' => 5, 'quantity' => 21241],
+            ['election_id' => 10, 'province_id' => 24, 'alternative_id' => 6, 'quantity' => 8773],
+            ['election_id' => 10, 'province_id' => 24, 'alternative_id' => 7, 'quantity' => 10066],
+            ['election_id' => 10, 'province_id' => 24, 'alternative_id' => 8, 'quantity' => 7735],
+        ];
+        foreach ($votesData as $voteData) {
+            Vote::create($voteData);
+        }
+    }
+}

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/provinces/create.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/provinces/create.blade.php
@@ -1,1 +1,0 @@
-<h1>Create Province</h1>

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/provinces/edit.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/provinces/edit.blade.php
@@ -1,1 +1,0 @@
-<h1>Edit Province</h1>

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/provinces/index.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/provinces/index.blade.php
@@ -1,1 +1,0 @@
-<h1>Provinces Index View</h1>

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/votes/create.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/votes/create.blade.php
@@ -1,1 +1,70 @@
-<h1>Create Vote</h1>
+@extends('layouts.main-layout')
+
+@section('content')
+    <h2 class="text-3xl font-semibold text-center mt-6 mb-4">Add Votes</h2>
+    <div class="mt-auto mx-auto max-w-md space-y-4">
+        @if (session('error'))
+            <div class="bg-red-500 text-white p-4 rounded-lg shadow-md">
+                {{ session('error') }}
+            </div>
+        @endif
+        <form action="{{ route('votes.store') }}" method="POST">
+            @csrf
+            <div class="border rounded p-10">
+                <div>
+                    <label for="election" class="block text-gray-700 my-2">Election Date</label>
+                    <select id="election" name="election" class="border rounded px-3 py-2 w-full" tabindex="1">
+                        <option value="">Select Election Date</option>
+                        @foreach ($elections as $election)
+                            <option value="{{ $election->id }}" {{ old('election') == $election->id ? 'selected' : '' }}>
+                                {{ $election->date }}</option>
+                        @endforeach
+                    </select>
+                </div>
+
+                <div>
+                    <label for="province" class="block text-gray-700 my-2">Province</label>
+                    <select id="province" name="province" class="border rounded px-3 py-2 w-full" tabindex="2">
+                        <option value="">Select Province</option>
+                        @foreach ($provinces as $province)
+                            <option value="{{ $province->id }}" {{ old('province') == $province->id ? 'selected' : '' }}>
+                                {{ $province->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+
+                <div>
+                    <label for="alternative" class="block text-gray-700 my-2">Alternative</label>
+                    <select id="alternative" name="alternative" class="border rounded px-3 py-2 w-full" tabindex="3">
+                        <option value="">Select Alternative</option>
+                        @foreach ($alternatives as $alternative)
+                            <option
+                                value="{{ $alternative->id }}"{{ old('alternative') == $alternative->id ? 'selected' : '' }}>
+                                {{ $alternative->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+
+                <div>
+                    <label for="quantity" class="block text-gray-700 my-2">Quantity</label>
+                    <input id="quantity" name="quantity" type="number" class="border rounded px-3 py-2 w-full"
+                        value="{{ session('error') ? session('existingVotes') : old('quantity') }}" tabindex="4"
+                        min="0">
+                </div>
+            </div>
+            <div class="flex justify-between">
+                <a href="/"
+                    class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block"
+                    tabindex="5">Cancel</a>
+                @if (session('error'))
+                    <a href="{{ session('editLink') }}"
+                        class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block"
+                        tabindex="7">Edit</a>
+                @endif
+                <button type="submit"
+                    class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block"
+                    tabindex="6">Submit</button>
+            </div>
+        </form>
+        <div></div>
+    @endsection

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/votes/edit.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/votes/edit.blade.php
@@ -1,1 +1,63 @@
-<h1>Edit Vote</h1>
+@extends('layouts.main-layout')
+
+@section('content')
+    <h2 class="text-2xl font-semibold text-center mt-10">Edit these Votes</h2>
+    <form id="main-form" class="mt-auto mx-auto max-w-md space-y-4"
+        action="{{ route('votes.update', ['election','province','alternative','quantity']) }}" method="POST">
+        @csrf
+        @method('PUT')
+        <div>
+            <label for="election" class="block text-gray-700 my-2">Election Date</label>
+            <select id="election" name="election" class="border rounded px-3 py-2 w-full" tabindex="1" form="main-form">
+                <option value="">Select Election Date</option>
+                @foreach ($elections as $election)
+                    <option value="{{ $election->id }}" @if ($election->id == $vote->election->id) selected @endif>
+                        {{ $vote->election->date }}</option>
+                @endforeach
+            </select>
+        </div>
+
+        <div>
+            <label for="province" class="block text-gray-700 my-2">Province</label>
+            <select id="province" name="province" class="border rounded px-3 py-2 w-full" tabindex="2" form="main-form">
+                <option value="">Select Province</option>
+                @foreach ($provinces as $province)
+                    <option value="{{ $province->id }}" @if ($province->id == $vote->province->id) selected @endif>
+                        {{ $province->name }}</option>
+                @endforeach
+            </select>
+        </div>
+
+        <div>
+            <label for="alternative" class="block text-gray-700 my-2">Alternative</label>
+            <select id="alternative" name="alternative" class="border rounded px-3 py-2 w-full" tabindex="3"
+                form="main-form">
+                <option value="">Select Alternative</option>
+                @foreach ($alternatives as $alternative)
+                    <option value="{{ $alternative->id }}" @if ($alternative->id == $vote->alternative->id) selected @endif>
+                        {{ $alternative->name }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <label for="quantity" class="block text-gray-700 my-2">Quantity</label>
+            <input id="quantity" name="quantity" type="number" class="border rounded px-3 py-2 w-full"
+                value="{{ old('quantity', $vote->quantity) }}" min="0" tabindex="4" form="main-form">
+        </div>
+        <div class="flex justify-between">
+            <a href="/" class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block"
+                tabindex="5">Cancel</a>
+                <button type="submit"
+                class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block" tabindex="7"
+                form="main-form">Submit</button>
+            </div>
+        </form>
+        <form id="sub-form" class="mx-auto"
+        action="{{ route('votes.destroy-votes', [$vote->election_id, $vote->province_id, $vote->alternative_id]) }}" method="POST">
+            @csrf
+            @method('DELETE')
+            <button type="submit" form="sub-form"
+                class="flex justify-between bg-red-400 hover:bg-red-700 text-white font-bold py-2 px-4 m-4 rounded mx-auto"
+                tabindex="3">Delete</button>
+        </form>
+@endsection

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/votes/index.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/votes/index.blade.php
@@ -1,1 +1,0 @@
-<h1>Votes Index View</h1>

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/votes/show-vote.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/votes/show-vote.blade.php
@@ -1,0 +1,45 @@
+@extends('layouts.main-layout')
+
+@section('content')
+    <h2 class="text-2xl font-semibold text-center my-10">Vote details</h2>
+    <div class="mt-auto mx-auto max-w-md space-y-4">
+        <div class="border rounded p-10">
+            <table>
+                <label for="date" class="block text-gray-700 py-3">Election's date</label>
+                <div id="date" class="border rounded px-3 py-2 w-full text-center">
+                    {{ $vote->election->date }}
+                </div>
+                <label for="province" class="block text-gray-700 py-3">Province</label>
+                <div id="province" class="border rounded px-3 py-2 w-full text-center">
+                    {{ $vote->province->name }}
+                </div>
+                <label for="alternative" class="block text-gray-700 py-3">Alternative</label>
+                <div id="alternative" class="border rounded px-3 py-2 w-full text-center">
+                    {{ $vote->alternative->name }}
+                </div>
+                <label for="quantity" class="block text-gray-700 py-3">Quantity</label>
+                <div id="quantity" class="border rounded px-3 py-2 w-full text-center">
+                    {{ $vote->quantity }}
+                </div>
+            </table>
+        </div>
+
+        <div class="flex justify-between items-center">
+            <a href="{{ route('votes.edit', [$year, $vote->province_id, $vote->alternative_id]) }}"
+                class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block"
+                tabindex="1">Edit</a>
+
+            <form class="mx-auto"
+                action="{{ route('votes.destroy-votes', [$vote->election_id, $vote->province_id, $vote->alternative_id]) }}"
+                method="POST">
+                @csrf
+                @method('DELETE')
+                <button type="submit"
+                    class="flex justify-between bg-red-400 hover:bg-red-700 text-white font-bold py-2 px-4 m-4 rounded mx-auto"
+                    tabindex="3">Delete</button>
+            </form>
+        <a href={{"/results/$year"}} class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block"
+                tabindex="2">Back</a>
+        </div>
+    </div>
+@endsection

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/routes/web.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/routes/web.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Http\Controllers\ResultsController;
+use App\Http\Controllers\VotesController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -23,7 +25,16 @@ Route::resource('elections','App\Http\Controllers\ElectionsController');
 
 Route::resource('provinces','App\Http\Controllers\ProvincesController');
 
-Route::resource('votes','App\Http\Controllers\VotesController');
+Route::resource('votes', VotesController::class);
+
+// Show a particular register of a vote
+Route::get('votes/{election_id}/{province_id}/{alternative_id}', [VotesController::class, 'showVote'])->name('votes.showVote');
+
+// Delete/destroy a particular register of a vote
+Route::delete('votes/{election_id}/{province_id}/{alternative_id}', [VotesController::class, 'destroy'])->name('votes.destroy-votes');
+
+// Edit a particular register of a vote
+Route::get('votes/{year}/{province_id}/{alternative_id}/edit', [VotesController::class, 'edit'])->name('votes.edit');
 
 Route::middleware([
     'auth:sanctum',


### PR DESCRIPTION
# PR#11 feature/votes-crud

## Votes Controller:
### Index:
Deleted.
### Create:
Redirects to the form view for vote creation with the necessary data for select fields.
### Store:
- Checks if the vote to be created already exists.
 - YES:
  - It doesn't save it and redirects back to the same form with the same data, displaying an error message and an "edit" button.
   - If votes were previously entered, it displays their values; otherwise, it uses the "old" values.
 - NOT:
   - Creates a new record and redirects to the show vote view.
- [ ] TODO: Implement error messages if validation fails.
### ShowVote:
- First, it retrieves the election based on the year in the URL.
 - [ ] TODO: Consider creating a helper to find the date of the year and vice versa for consistent use.
- Then it fetches the vote for that election and the other parameters in the URL.
 - [ ] TODO: Improve the redirection if the election is not found.
- Returns to the show vote view with the data.
### Edit:
- Redirects to `edit.blade.php` after validating if it finds the election.
 - Sends the data to use in the select fields.
 - If votes have not been entered, a message suggests adding them using the "create" form.
### Update:
- Validates user inputs.
- Checks whether the votes are already entered.
 - If they are, it updates them. If not, it creates them.
 - Redirects to the main votes table for the current year.
 - [x] L149: Standardize the syntax for accessing variables, choose between `$request->input('election')` or `$request->election`
### Destroy:
- Deletes a vote based on the method called.
- [x] TODO: Add logic to prevent the deletion of "Spoiled" and "Blank" alternatives.
## Vote Model:
- Set a composite primary key with "election," "Province," and "Alternative."
- Defined relationships with other tables.
- Specified mass fillable fields.
## Vote Migration:
- Removed "on cascade" restrictions and the id field.
  - [ ] TODO: Verify if this is the correct approach.
## Views:
### Create:
- Introduced a vote submission form.
- Enhanced error handling and provided editing options in case of duplicate entries.
### Edit:
- Edit form for existing votes.
 - [ ] Add a border.
 - [x] Check the URL for the "cancel" button.
### ShowVote:
- Displays vote details based on parameters with options to go back or delete the record.
## Routes:
- Updated route syntax to match the latest Laravel version.
- Defined routes like `votes.showVote`, `votes.destroy-votes`, `votes.edit` to perform these actions on specific vote records.
- [x] TODO: Adapt routes for other controllers to the new method as done in Votes.
---
### Old PR's TODOs
### PR#5
## Pending Tasks:
### PR#8 Alternatives CRUD
- [x] Configure error handling using `@error` directives in `create.blade.php` and `edit.blade.php`
- [ ] Abstract the concept of default alternatives to avoid conditional statements in `edit.blade.php`
- [x] Fix the buttons in `alternatives.index`
- [x] Add a dashboard layout.
- [ ] Decide how to handle alternative logos (e.g., file uploads or URLs).
### PR#5 Set routes and views
- [x] Implement a base template layout (e.g., Bootstrap) 
- [x] Create the dashboard for registered users (AdminLTE) for the user interface.
- [ ] Protect controller methods to ensure that only authenticated users can access certain routes. Use the `$this->middleware('auth');` code snippet below the controller definition.
- [ ] Implement a role-based access control system to manage user permissions and province assignments.
- [ ] Add a "Province" field to the user registration form to enable province assignment roles for editing their respective provinces.
- [ ] Consider using Livewire or similar for improved interactivity without extensive JavaScript.
### PR#3 CRUD controllers
- [ ] Install components like DataTables for improved tabular data visualization (JavaScript required).