### PR TITLE
Feature/crud alternatives

### DIFF
--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/alternatives/create.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/alternatives/create.blade.php
@@ -1,42 +1,38 @@
 @extends('layouts.main-layout')
 
 @section('content')
-    <h2 class="text-2xl font-semibold text-center mt-10">Add an Alternative</h2>
-    <form action="/alternatives/store" method="POST" class="mt-auto mx-auto max-w-md space-y-4">
+    <h2 class="text-2xl font-semibold text-center m-10">Add an Alternative</h2>
+    <form action="{{ route('alternatives.store') }}" method="POST" class="border p-5 m-auto mx-auto max-w-md space-y-4">
         @csrf
 
-        <div>
-            <label for="name" class="block text-gray-700">Name</label>
-            <input id="name" name="name" type="text"
-                class="border rounded px-3 py-2 w-full
+        <label for="name" class="block  text-gray-700">Name</label>
+        <input id="name" name="name" type="text"
+            class="border px-3 py-2 w-full
                 @error('name') border-red-500 @enderror"
-                value="{{ old('name') }}" tabindex="1">
-            @error('name')
-                <small class="text-red-500">{{ $message }}</small>
-            @enderror
-        </div>
+            value="{{ old('name') }}" tabindex="1">
+        @error('name')
+            <small class="text-red-500">{{ $message }}</small>
+        @enderror
 
-        <div>
-            <label for="candidates" class="block text-gray-700">President and Vice candidates</label>
-            <input id="candidates" name="candidates" type="text"
-                class="border rounded px-3 py-2 w-full
-                @error('candidates') border-red-500 @enderror"
-                value="{{ old('candidates') }}" tabindex="2">
-        </div>
+        <label for="presi_vice" class="block text-gray-700">President and Vice candidates</label>
+        <input id="presi_vice" name="presi_vice" type="text"
+            class="border rounded px-3 py-2 w-full
+                @error('presi_vice') border-red-500 @enderror"
+            value="{{ old('presi_vice') }}" tabindex="2">
 
-        <div>
-            <label for="logo" class="block text-gray-700">URL-Logo</label>
-            <input id="logo" name="logo" type="text"
-                class="border rounded px-3 py-2 w-full
-                @error('candidates') border-red-500 @enderror"
-                value="{{ old('logo') }}" tabindex="3">
-        </div>
+        <label for="logo" class="block text-gray-700">URL-Logo</label>
+        <input id="logo" name="logo" type="text"
+            class="border rounded px-3 py-2 w-full
+                @error('logo') border-red-500 @enderror"
+            value="{{ old('logo') }}" tabindex="3">
+
         <div class="flex justify-between">
-            <a href="/" class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block"
-                tabindex="5">Cancel</a>
+            <a href="/alternatives"
+                class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block"
+                tabindex="4">Cancel</a>
             <button type="submit"
                 class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block"
-                tabindex="6">Submit</button>
+                tabindex="5">Submit</button>
         </div>
     </form>
 @endsection

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/alternatives/edit.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/alternatives/edit.blade.php
@@ -1,13 +1,13 @@
 @extends('layouts.main-layout')
 
 @section('content')
-    <h2 class="text-2xl font-semibold text-center mt-10">Edit an Alternative</h2>
-    <form action="/alternatives/{{ $alternative->id }}" method="POST" class="mt-auto mx-auto max-w-md space-y-4">
+    <h2 class="text-2xl font-semibold text-center m-10">Edit an Alternative</h2>
+    <form action="/alternatives/{{ $alternative->id }}" method="POST" class="border rounded p-5 m-auto mx-auto max-w-md space-y-4">
         @csrf
         @method('PUT')
 
-        <div>
             <label for="name" class="block text-gray-700">Name</label>
+            @if (!($alternative->isblank() || $alternative->isSpoiled()))
             <input id="name" name="name" type="text"
                 class="border rounded px-3 py-2 w-full
                 @error('name') border-red-500 @enderror"
@@ -15,22 +15,27 @@
             @error('name')
                 <small class="text-red-500">{{ $message }}</small>
             @enderror
-        </div>
+            @else
+                <div id="name" name="name" type="text" class="border rounded px-3 py-2 w-full">
+                    {{ $alternative->name }}
+                </div>
+            @endif
+
         {{-- TODO: Abstract this concept in default alternatives to avoid these ifs --}}
         @if (!($alternative->isblank() || $alternative->isSpoiled()))
-            <div>
-                <label for="candidates" class="block text-gray-700">President and Vice candidates</label>
-                <input id="candidates" name="candidates" type="text" class="border rounded px-3 py-2 w-full"
-                    value="{{ old('candidates', $alternative->presi_vice) }}" tabindex="2">
-            </div>
+
+                <label for="presi_vice" class="block text-gray-700">President and Vice candidates</label>
+                <input id="presi_vice" name="presi_vice" type="text" class="border rounded px-3 py-2 w-full"
+                    value="{{ old('presi_vice', $alternative->presi_vice) }}" tabindex="2">
+
         @endif
-        <div>
+
             <label for="logo" class="block text-gray-700">URL-Logo</label>
             <input id="logo" name="logo" type="text" class="border rounded px-3 py-2 w-full"
                 value="{{ old('logo', $alternative->logo) }}" tabindex="3">
-        </div>
+
         <div class="flex justify-between">
-            <a href="/" class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block"
+            <a href="/alternatives" class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block"
                 tabindex="5">Cancel</a>
             <button type="submit"
                 class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded inline-block"

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/alternatives/index.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/alternatives/index.blade.php
@@ -1,41 +1,70 @@
 @extends('layouts.main-layout')
 
 @section('content')
-    <h2 class="text-2xl font-semibold text-center mt-10">Alternatives</h2>
-    <div class="mt-4 mx-auto p-20">
-        <table class="min-w-full border-collapse border">
-            <thead>
-                <tr>
-                    <th
-                        class="px-6 py-3 bg-gray-200 text-left text-xs leading-4 font-medium text-gray-600 uppercase tracking-wider">
-                        Name</th>
-                    <th class="px-6 py-3 bg-gray-200"></th>
+    <h2 class="text-2xl font-semibold text-center m-5">Alternatives</h2>
+    @if (session('error'))
+        <div class="flex max-w-3xl mx-auto mb-3 bg-yellow-400 text-black text-center p-4 rounded-lg shadow-md justify-around">
+            <form action="{{ route('alternatives.destroy', session('id')) }}" method="POST">
+                @csrf
+                @method('DELETE')
+                <p>{{ session('error') }}</p>
+                <input type="checkbox" name="confirm-delete" id="confirm-delete">
+                <label for="confirm-delete">Yes, I'm sure</label>
+                <button type="submit"
+                    class="text-white bg-red-600 hover:bg-red-900 font-bold m-4 py-2 px-4 rounded">Delete</button>
+                    <a href="/alternatives"
+                    class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 m-4 rounded  inline-block"
+                    tabindex="4">Cancel</a>
+                </form>
+        </div>
+    @endif
+    @if (session('error-2'))
+        <div class="max-w-3xl mx-auto mb-3 bg-red-400 text-white text-center p-4 rounded-lg shadow-md">
+            {{ session('error-2') }}
+        </div>
+    @endif
+    <table class="max-w-3xl border-collapse border mx-auto p-10">
+        <thead>
+            <tr>
+                <th
+                    class="px-6 py-3 bg-gray-200 text-left text-base leading-4 font-medium text-gray-700 uppercase tracking-wider">
+                    Name
+                </th>
+                <th class="px-6 py-3 bg-gray-200"></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($alternatives as $alternative)
+                <tr class="border border-collapse">
+                    @if (!($alternative->isblank() || $alternative->isSpoiled()))
+                        <td class="border px-6 py-5">{{ $alternative->name }}</td>
+                        <td class="m-2 my-4 flex justify-around h-full">
+                            <a href="{{ route('alternatives.show', $alternative->id) }}"
+                                class="text-white bg-blue-400 hover-bg-blue-700 font-bold mx-2 py-2 px-4 rounded h-full">View</a>
+                            <a href="{{ route('alternatives.edit', $alternative->id) }}"
+                                class="text-white bg-blue-600 hover-bg-blue-900 font-bold mx-2 py-2 px-4 rounded h-full">Edit</a>
+                            <form action="{{ route('alternatives.destroy', $alternative->id) }}" method="POST"
+                                class="inline">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit"
+                                    class="text-white bg-red-600 hover-bg-red-900 font-bold mx-2 py-2 px-4 rounded h-full"
+                                    onclick="return confirm('Are you sure you want to delete this alternative?')">Delete</button>
+                            </form>
+                        </td>
+                    @endif
                 </tr>
-            </thead>
-            <tbody>
-                @foreach ($alternatives as $alternative)
-                    <tr>
-                        <td class="border px-6 py-4">{{ $alternative->name }}</td>
-                        <td class="border px-6 py-4 text-right">
-                                @if (!($alternative->isblank() || $alternative->isSpoiled()))
-                                <a href="{{ route('alternatives.edit', $alternative->id) }}"
-                                    class="text-white bg-blue-400 hover:bg-blue-700 font-bold py-2 px-4 m-4 rounded mr-3">Edit</a>
-                                <form action="{{ route('alternatives.destroy', $alternative->id) }}" method="POST"
-                                    class="inline">
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit"
-                                        class="text-white bg-red-600 hover:bg-red-900 font-bold py-2 px-4 m-4 rounded mr-3">Delete</button>
-                                </form>
-                                @endif
-                            </td>
-                    </tr>
-                @endforeach
-            </tbody>
-        </table>
-    </div>
-
-    <div class="text-center mt-4">
-        <a href="/" class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block">Back</a>
+            @endforeach
+        </tbody>
+    </table>
+    <div class="max-w-3xl mx-auto my-5 flex justify-around">
+        <div class="text-center">
+            <a href="/"
+                class="bg-blue-400 hover-bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block">Back</a>
+        </div>
+        <div class="text-center">
+            <a href="{{ route('alternatives.create') }}"
+                class="bg-blue-400 hover-bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block">Create</a>
+        </div>
     </div>
 @endsection

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/alternatives/show.blade.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/resources/views/entities/alternatives/show.blade.php
@@ -1,35 +1,36 @@
 @extends('layouts.main-layout')
 
 @section('content')
-    <h2 class="text-2xl font-semibold text-center mt-10">Alternative</h2>
-    <div class="mt-auto mx-auto max-w-md space-y-4">
-        <table>
-            <div>
+    <h2 class="text-2xl font-semibold text-center m-8">Alternative</h2>
+    <div class="border rounded p-5 my-10 mx-auto max-w-md space-y-4">
+        <table class="border rounded px-3 py-2">
                 <label for="name" class="block text-gray-700">Name</label>
                 <div id="name" name="name" type="text" class="border rounded px-3 py-2 w-full">
                     {{ $alternative->name }}
                 </div>
                 {{-- TODO: Abstract this concept in default alternatives to avoid this if --}}
-                @if (!($alternative->isblank() || $alternative->isSpoiled()))
-                <div>
-                    <label for="candidates" class="block text-gray-700">President and Vice candidates</label>
-                    <div id="name" name="name" type="text" class="border rounded px-3 py-2 w-full">
-                        {{ $alternative->presi_vice }}
-                    </div>
-                </div>
+                @if (!($alternative->isblank() || $alternative->isSpoiled() || empty($alternative->presi_vice)))
+                        <label for="presi_vice" class="block text-gray-700">President and Vice candidates</label>
+                        <div class="border rounded px-3 py-2 w-full">
+                            {{ $alternative->presi_vice }}
+                        </div>
                 @endif
                 @if (!empty($alternative->logo))
-                    <div>
-                        <label for="candidates" class="block text-gray-700">President and Vice candidates</label>
-                        <div id="name" name="name" type="text" class="border rounded px-3 py-2 w-full">
+                    <div class="border rounded px-3 py-2">
+                        <label for="logo" class="block text-gray-700">URL-Logo</label>
+                        <div id="logo" name="logo" type="text" class="px-3 py-2 w-full">
                             {{ $alternative->logo }}
                         </div>
                     </div>
                 @endif
-            </div>
         </table>
-        <div class="text-center mt-4">
-            <a href="/"
-                class="bg-blue-400 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block">Back</a>
+        <div class="text-center flex justify-around mt-4 space-x-2">
+            <a href="/alternatives"
+                class="bg-blue-400 hover-bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block">Back</a>
+            @if (!($alternative->isblank() || $alternative->isSpoiled()))
+                <a href="/alternatives/{{ $alternative->id }}/edit"
+                    class="bg-blue-400 hover-bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block">Edit</a>
+            @endif
         </div>
-    @endsection
+    </div>
+@endsection

--- a/CursoPHP-Sprint4-Laravel/ArgentineElections/routes/web.php
+++ b/CursoPHP-Sprint4-Laravel/ArgentineElections/routes/web.php
@@ -1,8 +1,9 @@
 <?php
 
-use App\Http\Controllers\ResultsController;
+use App\Http\Controllers\AlternativesController;
 use App\Http\Controllers\VotesController;
 use Illuminate\Support\Facades\Route;
+
 
 /*
 |--------------------------------------------------------------------------
@@ -19,7 +20,7 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::resource('alternatives','App\Http\Controllers\AlternativesController');
+Route::resource('alternatives', AlternativesController::class);
 
 Route::resource('elections','App\Http\Controllers\ElectionsController');
 


### PR DESCRIPTION
# PR #12 Crud alternatives
## Changes:
### Web.php
- Updated the resource alternatives route to use the current Laravel syntax and called the AlternativesController.
- [x] Delete routes and/or the ProvincesController itself.
### Views:
There are 4 views - Create, Edit, Index, and Show, and they all work correctly.
#### Index
- Changed the style to a table.
- Added a "Create" button.
- Excluded Blank and Spoiled alternatives from the list.
- Fixed the delete button by modifying the destroy() method in the controller.
- Added a confirmation if the alternative has associated votes.
- [x] Set the correct route for the Back button.
#### Create
- Used the new route syntax, calling `alternatives.store`
- Line 17: Changed id, for, and name from 'candidates' to 'presi_vice'.
- Set the cancel button to go to the alternatives index.
- Changed the styles.
#### Edit
- Changed id, for, and name in the form from 'candidates' to 'presi_vice'.
- The Back button now sends you to the alternatives index.
- If the section doesn't allow editing the name field if it's blank or spoiled.
- Changed the styles.
#### Show
- Added a border to fields.
- The Back button now goes to the alternatives index.
- Added a new 'Edit' button which doesn't appear on Blank and Spoiled alternatives.
- The President-vice field is not shown for Blank and Spoiled alternatives or if it's null.
### Controller
- Added a 404 error message in show() and destroy() if the alternative is not found.
#### Destroy:
- Added a confirmation if the user really wants to delete an alternative with associated votes.
- If the user confirms, it first deletes the votes and then the alternative.
## TODO
- [x] Execute migrations because several alternatives were deleted.
- [x] The "Select Election" in the edit votes form doesn't work. It shows the same date many times